### PR TITLE
KT-206 Add destination_id for FLA to config report

### DIFF
--- a/examples/TetraScience Scientific Data Cloud Configuration Report.ipynb
+++ b/examples/TetraScience Scientific Data Cloud Configuration Report.ipynb
@@ -1,563 +1,570 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "433e5acb",
-   "metadata": {
-    "id": "433e5acb"
-   },
-   "source": [
-    "# TetraScience Scientific Data Cloud Configuration Report\n",
-    "This script generates an Excel report with Agent and Pipeline configuration details for a Tetra Data Platform (TDP) organization.\n",
-    "\n",
-    "Executing this script requires an Administrator user's personal token, or a token from a Service User with the Administrator role.\n",
-    "\n",
-    "Replace the values in <brackets> in the \"Notebook Parameters\" section below, and run all cells. When prompted in the \"Notebook Parameters\" cell, paste a valid authentication token into the input box and hit return/enter.\n",
-    "\n",
-    "The output of this script is an Excel file in the `SAVE_DIR` location. If using Google Colab, you can find and download the file from Files browser in the sidebar with the default location."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "433e5acb",
+      "metadata": {
+        "id": "433e5acb"
+      },
+      "source": [
+        "# TetraScience Scientific Data Cloud Configuration Report\n",
+        "This script generates an Excel report with Agent and Pipeline configuration details for a Tetra Data Platform (TDP) organization.\n",
+        "\n",
+        "Executing this script requires an Administrator user's personal token, or a token from a Service User with the Administrator role.\n",
+        "\n",
+        "Replace the values in <brackets> in the \"Notebook Parameters\" section below, and run all cells. When prompted in the \"Notebook Parameters\" cell, paste a valid authentication token into the input box and hit return/enter.\n",
+        "\n",
+        "The output of this script is an Excel file in the `SAVE_DIR` location. If using Google Colab, you can find and download the file from Files browser in the sidebar with the default location."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9df752cc",
+      "metadata": {
+        "id": "9df752cc"
+      },
+      "source": [
+        "## Import Statements"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ebc95765",
+      "metadata": {
+        "id": "ebc95765"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import json\n",
+        "import requests\n",
+        "from datetime import datetime\n",
+        "from zoneinfo import ZoneInfo\n",
+        "import pandas as pd\n",
+        "import getpass"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1ebe7331",
+      "metadata": {
+        "id": "1ebe7331"
+      },
+      "source": [
+        "## Notebook Parameters\n",
+        "Required parameters:\n",
+        "* `API_URL` = API base URL for your TDP instance, ending in \"/v1/\"\n",
+        " * The format is `https://api.<your TDP hostname>/v1/` -- e.g. `https://api.tetrascience.com/v1/`\n",
+        "* `ORG_SLUG` = organization slug for the target TDP organization\n",
+        " * Locate this in the platform in Administration > Organization Settings > Settings in the \"Organization Slug\" pane\n",
+        "* `AUTH_TOKEN` = You will be prompted to paste in a value, which must be an Administrator level personal access token for TDP, or token of a Service User with the Administrator role\n",
+        " * See the linked pages from the [Create a JWT documentation](https://developers.tetrascience.com/reference/authentication#create-a-jwt) for details on these options.\n",
+        "\n",
+        "Optional parameters, you may leave the default values:\n",
+        "* `SAVE_DIR` = directory on your local machine to save the output Excel file\n",
+        " * Leave the default value `./` to save in the same location as this notebook file\n",
+        "* `TZ_IDENTIFIER` = Time zone identifier in the `tz database` used to generate the timestamp in the filename\n",
+        " * More information about Time Zones in Python can be found [here](https://docs.python.org/3/library/zoneinfo.html).\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cde2d8a9",
+      "metadata": {
+        "id": "cde2d8a9"
+      },
+      "outputs": [],
+      "source": [
+        "API_URL = \"\"\n",
+        "ORG_SLUG = \"\"\n",
+        "\n",
+        "SAVE_DIR = \"./\"\n",
+        "TZ_IDENTIFIER = \"America/New_York\"\n",
+        "\n",
+        "AUTH_TOKEN = getpass.getpass()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9a9227b0",
+      "metadata": {
+        "id": "9a9227b0"
+      },
+      "source": [
+        "## Create filename\n",
+        "\n",
+        "This uses the current date and time to document when the configuration was retrieved from the platform."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f568cd1d",
+      "metadata": {
+        "id": "f568cd1d"
+      },
+      "outputs": [],
+      "source": [
+        "now = datetime.now(ZoneInfo(TZ_IDENTIFIER))\n",
+        "timestamp = now.strftime(\"%Y-%m-%d %H:%M:%S\")\n",
+        "filenameBase = \"TDP-config-report__\" + ORG_SLUG + \"__\"\n",
+        "savefile_name = os.path.join(SAVE_DIR, filenameBase + now.strftime(\"%Y-%m-%d-%H%M%S\") + \".xlsx\")\n",
+        "print(\"savefile_name =\", savefile_name)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "06f2859a",
+      "metadata": {
+        "id": "06f2859a"
+      },
+      "source": [
+        "## Use Authentication File for API Headers"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "bfbbb010",
+      "metadata": {
+        "id": "bfbbb010"
+      },
+      "outputs": [],
+      "source": [
+        "headers = {\"ts-auth-token\": AUTH_TOKEN,\n",
+        "           \"x-org-slug\": ORG_SLUG}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "bca751c7",
+      "metadata": {
+        "id": "bca751c7"
+      },
+      "source": [
+        "## API Endpoints"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e74fc609",
+      "metadata": {
+        "id": "e74fc609"
+      },
+      "outputs": [],
+      "source": [
+        "PIPELINE_SEARCH = API_URL + \"pipeline/search\"\n",
+        "AGENT_LIST = API_URL + \"agents?include=labels\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "915b0140",
+      "metadata": {
+        "id": "915b0140"
+      },
+      "source": [
+        "## Export Info Sheet"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d6c34d00",
+      "metadata": {
+        "id": "d6c34d00"
+      },
+      "outputs": [],
+      "source": [
+        "info_data = {\"Name\": [\"timestamp\", \"API_URL\", \"ORG_SLUG\", \"TZ_IDENTIFIER\"], \"Value\": [timestamp, API_URL, ORG_SLUG, TZ_IDENTIFIER]}\n",
+        "info_df = pd.DataFrame(data=info_data)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "dd3cf0ea",
+      "metadata": {
+        "id": "dd3cf0ea"
+      },
+      "outputs": [],
+      "source": [
+        "print(info_df.to_string(index=False, header=False))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f1fad526",
+      "metadata": {
+        "id": "f1fad526"
+      },
+      "source": [
+        "## Pipeline Configuration Sheet"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f0b7f212",
+      "metadata": {
+        "id": "f0b7f212"
+      },
+      "outputs": [],
+      "source": [
+        "def get_pipeline_page(headers, **kwargs):\n",
+        "    \"\"\"\n",
+        "        Returns a set of pipelines and whether there are more\n",
+        "        pipelines remaining\n",
+        "        Optional args: page_size, page_index\n",
+        "    \"\"\"\n",
+        "    pipeline_api = PIPELINE_SEARCH + \"?\"\n",
+        "    if \"index\" in kwargs.keys():\n",
+        "        page_index = kwargs[\"index\"]\n",
+        "        pipeline_api += \"from=\" + str(page_index) + \"&\"\n",
+        "    if \"size\" in kwargs.keys():\n",
+        "        page_size = kwargs[\"size\"]\n",
+        "        pipeline_api += \"size=\" + str(page_size) + \"&\"\n",
+        "\n",
+        "    pipeline_response = requests.get(pipeline_api, headers=headers)\n",
+        "    pipeline_response = json.loads(pipeline_response.text)\n",
+        "\n",
+        "    return pipeline_response[\"hits\"], pipeline_response[\"hasNext\"]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "22c4af5c",
+      "metadata": {
+        "id": "22c4af5c"
+      },
+      "outputs": [],
+      "source": [
+        "def get_all_pipelines(headers, size=1):\n",
+        "    \"\"\"\n",
+        "        Returns list of all pipelines by iterating over full list\n",
+        "        by the size parameter.\n",
+        "    \"\"\"\n",
+        "    hasNext = True\n",
+        "    index = 0\n",
+        "    all_pipelines = []\n",
+        "    while hasNext == True:\n",
+        "        pipes, hasNext = get_pipeline_page(headers, size=size, index=index)\n",
+        "        all_pipelines += pipes\n",
+        "        index += 1\n",
+        "    return all_pipelines"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "2f91685d",
+      "metadata": {
+        "id": "2f91685d"
+      },
+      "outputs": [],
+      "source": [
+        "pipeline_list = get_all_pipelines(headers)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d8f49795",
+      "metadata": {
+        "id": "d8f49795"
+      },
+      "outputs": [],
+      "source": [
+        "pipeline_top_fields = [\"id\",\n",
+        "                        \"name\",\n",
+        "                        \"description\",\n",
+        "                        \"status\",\n",
+        "                        \"createdAt\",\n",
+        "                        \"updatedAt\",\n",
+        "                        \"triggerCondition\",\n",
+        "                        \"maxParallelWorkflows\",\n",
+        "                        \"priority\",\n",
+        "                        \"retryBehavior\",\n",
+        "                        \"retryConfiguration\",\n",
+        "                        \"protocolSlug\",\n",
+        "                        \"protocolVersion\",\n",
+        "                        \"pipelineConfig\",\n",
+        "                        \"stepsConfig\"]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "28164873",
+      "metadata": {
+        "id": "28164873"
+      },
+      "outputs": [],
+      "source": [
+        "def pipeline_summary(pipeline_info, org):\n",
+        "\n",
+        "    pipeline_top_vals = [org] + [pipeline_info[x] for x in pipeline_top_fields]\n",
+        "\n",
+        "    return pipeline_top_vals"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d6318362",
+      "metadata": {
+        "id": "d6318362"
+      },
+      "outputs": [],
+      "source": [
+        "pipeline_summaries = [pipeline_summary(a, ORG_SLUG) for a in pipeline_list]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "30368c21",
+      "metadata": {
+        "id": "30368c21"
+      },
+      "outputs": [],
+      "source": [
+        "pipeline_df = pd.DataFrame(pipeline_summaries, columns = [\"orgSlug\"] + pipeline_top_fields)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "beeb724f",
+      "metadata": {
+        "scrolled": true,
+        "id": "beeb724f"
+      },
+      "outputs": [],
+      "source": [
+        "pipeline_df"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "845bfbe0",
+      "metadata": {
+        "id": "845bfbe0"
+      },
+      "source": [
+        "## Agent Configuration Sheet"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "bb8e0a4c",
+      "metadata": {
+        "id": "bb8e0a4c"
+      },
+      "outputs": [],
+      "source": [
+        "agent_response = requests.get(AGENT_LIST, headers=headers)\n",
+        "agent_list = json.loads(agent_response.text)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "4530ffa0",
+      "metadata": {
+        "id": "4530ffa0"
+      },
+      "outputs": [],
+      "source": [
+        "agent_list"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1dfc37ac",
+      "metadata": {
+        "id": "1dfc37ac"
+      },
+      "outputs": [],
+      "source": [
+        "agent_top_fields = [\"orgSlug\",\n",
+        "                    \"name\",\n",
+        "                    \"description\",\n",
+        "                    \"id\",\n",
+        "                    \"isEnabled\",\n",
+        "                    \"status\",\n",
+        "                    \"version\",\n",
+        "                    \"labels\",\n",
+        "                    \"tags\",\n",
+        "                    \"metadata\",\n",
+        "                    \"host\",\n",
+        "                    \"createdAt\",\n",
+        "                    \"updatedAt\",\n",
+        "                    \"configStatusUpdatedAt\",\n",
+        "                    \"type\",\n",
+        "                    \"liveType\",\n",
+        "                    \"integrationType\",\n",
+        "                    \"integrationId\"]\n",
+        "agent_queue_fields = [\"queue_enabled\"]\n",
+        "agent_config_fields = [\"destination_id\"]\n",
+        "agent_paths_fields = [\"paths\",\n",
+        "                      \"paths_start_date\",\n",
+        "                      \"paths_source_type\",\n",
+        "                      \"paths_interval\",\n",
+        "                      \"paths_labels\",\n",
+        "                      \"paths_tags\",\n",
+        "                      \"paths_metadata\",\n",
+        "                      \"paths_patterns\",\n",
+        "                      \"paths_filewatchmode\",\n",
+        "                      \"paths_fetch_os_created_user\",\n",
+        "                      \"paths_archive\"]\n",
+        "agent_fields = agent_top_fields + agent_queue_fields + agent_config_fields + agent_paths_fields"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "754f5566",
+      "metadata": {
+        "id": "754f5566"
+      },
+      "outputs": [],
+      "source": [
+        "def try_getting_from_path(path_info, field):\n",
+        "    try:\n",
+        "        return path_info[field]\n",
+        "    except:\n",
+        "        return None\n",
+        "\n",
+        "def agent_summary(agent_info):\n",
+        "    agent_top_vals = [agent_info[x] for x in agent_top_fields]\n",
+        "\n",
+        "    if agent_info[\"queue\"]:\n",
+        "        agent_queue_vals = [agent_info[\"queue\"][\"enabled\"]]\n",
+        "    else:\n",
+        "        agent_queue_vals = [\"N/A\"]*len(agent_queue_fields)\n",
+        "\n",
+        "    agent_config_vals = []\n",
+        "    for f in agent_config_fields:\n",
+        "        if (agent_info[\"type\"] == \"file-log\") and (agent_info[\"config\"] is not None) and (agent_info[\"config\"].get(f) is not None):\n",
+        "            agent_config_vals.append(agent_info[\"config\"][f])\n",
+        "        else:\n",
+        "            agent_config_vals.append(\"N/A\")\n",
+        "\n",
+        "    # Additionally get File-Log Agent Configuration Information\n",
+        "    if (agent_info[\"type\"] == \"file-log\") and (agent_info[\"config\"] is not None):\n",
+        "        paths_info = agent_info[\"config\"][\"services_configuration\"][\"fileWatcher\"][\"paths\"]\n",
+        "\n",
+        "        agent_subvals = [[x[\"path\"] for x in paths_info],\n",
+        "                         [x[\"start_date\"] for x in paths_info],\n",
+        "                         [x[\"source_type\"] for x in paths_info],\n",
+        "                         [x[\"interval\"] for x in paths_info],\n",
+        "                         [try_getting_from_path(x, \"labels\") for x in paths_info],\n",
+        "                         [try_getting_from_path(x, \"metadata\") for x in paths_info],\n",
+        "                         [try_getting_from_path(x, \"tags\") for x in paths_info],\n",
+        "                         [x[\"patterns\"] for x in paths_info],\n",
+        "                         [x[\"file_watch_mode\"] for x in paths_info],\n",
+        "                         [try_getting_from_path(x, \"fetch_os_created_user\") for x in paths_info],\n",
+        "                         [try_getting_from_path(x, \"archive\") for x in paths_info]]\n",
+        "    else:\n",
+        "        agent_subvals = [\"N/A\"]*len(agent_paths_fields)\n",
+        "\n",
+        "    return agent_top_vals + agent_queue_vals + agent_config_vals + agent_subvals"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f8dbfd7d",
+      "metadata": {
+        "id": "f8dbfd7d"
+      },
+      "outputs": [],
+      "source": [
+        "agent_summaries = [agent_summary(a) for a in agent_list]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a1d31f50",
+      "metadata": {
+        "id": "a1d31f50"
+      },
+      "outputs": [],
+      "source": [
+        "agent_df = pd.DataFrame(agent_summaries, columns = agent_fields)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e2441f6d",
+      "metadata": {
+        "scrolled": true,
+        "id": "e2441f6d"
+      },
+      "outputs": [],
+      "source": [
+        "agent_df"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d4afdf04",
+      "metadata": {
+        "id": "d4afdf04"
+      },
+      "source": [
+        "## Save to Excel"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "fb40222e",
+      "metadata": {
+        "id": "fb40222e"
+      },
+      "outputs": [],
+      "source": [
+        "with pd.ExcelWriter(savefile_name) as writer:\n",
+        "    info_df.to_excel(writer, sheet_name='Info', index=False, header=False)\n",
+        "    agent_df.to_excel(writer, sheet_name='Agent Cfg', index=False)\n",
+        "    pipeline_df.to_excel(writer, sheet_name='Pipeline Cfg', index=False)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.7"
+    },
+    "colab": {
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "9df752cc",
-   "metadata": {
-    "id": "9df752cc"
-   },
-   "source": [
-    "## Import Statements"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ebc95765",
-   "metadata": {
-    "id": "ebc95765"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import json\n",
-    "import requests\n",
-    "from datetime import datetime\n",
-    "from zoneinfo import ZoneInfo\n",
-    "import pandas as pd\n",
-    "import getpass"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1ebe7331",
-   "metadata": {
-    "id": "1ebe7331"
-   },
-   "source": [
-    "## Notebook Parameters\n",
-    "Required parameters:\n",
-    "* `API_URL` = API base URL for your TDP instance, ending in \"/v1/\"\n",
-    " * e.g. `https://api.tetrascience.com/v1/`\n",
-    "* `ORG_SLUG` = organization slug for the target TDP organization\n",
-    " * Locate this in the platform in Administration > Organization Settings > Settings in the \"Organization Slug\" pane\n",
-    "* `AUTH_TOKEN` = You will be prompted to paste in a value, which must be an Administrator level personal access token for TDP, or token of a Service User with the Administrator role\n",
-    " * See the linked pages from the [Create a JWT documentation](https://developers.tetrascience.com/reference/authentication#create-a-jwt) for details on these options.\n",
-    "\n",
-    "Optional parameters, you may leave the default values:\n",
-    "* `SAVE_DIR` = directory on your local machine to save the output Excel file\n",
-    " * Leave the default value `./` to save in the same location as this notebook file\n",
-    "* `TZ_IDENTIFIER` = Time zone identifier in the `tz database` used to generate the timestamp in the filename\n",
-    " * More information about Time Zones in Python can be found [here](https://docs.python.org/3/library/zoneinfo.html).\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cde2d8a9",
-   "metadata": {
-    "id": "cde2d8a9"
-   },
-   "outputs": [],
-   "source": [
-    "API_URL = \"\"\n",
-    "ORG_SLUG = \"\"\n",
-    "\n",
-    "SAVE_DIR = \"./\"\n",
-    "TZ_IDENTIFIER = \"America/New_York\"\n",
-    "\n",
-    "AUTH_TOKEN = getpass.getpass()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9a9227b0",
-   "metadata": {
-    "id": "9a9227b0"
-   },
-   "source": [
-    "## Create filename\n",
-    "\n",
-    "This uses the current date and time to document when the configuration was retrieved from the platform."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f568cd1d",
-   "metadata": {
-    "id": "f568cd1d"
-   },
-   "outputs": [],
-   "source": [
-    "now = datetime.now(ZoneInfo(TZ_IDENTIFIER))\n",
-    "timestamp = now.strftime(\"%Y-%m-%d %H:%M:%S\")\n",
-    "filenameBase = \"TDP-config-report__\" + ORG_SLUG + \"__\"\n",
-    "savefile_name = os.path.join(SAVE_DIR, filenameBase + now.strftime(\"%Y-%m-%d-%H%M%S\") + \".xlsx\")\n",
-    "print(\"savefile_name =\", savefile_name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "06f2859a",
-   "metadata": {
-    "id": "06f2859a"
-   },
-   "source": [
-    "## Use Authentication File for API Headers"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bfbbb010",
-   "metadata": {
-    "id": "bfbbb010"
-   },
-   "outputs": [],
-   "source": [
-    "headers = {\"ts-auth-token\": AUTH_TOKEN,\n",
-    "           \"x-org-slug\": ORG_SLUG}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bca751c7",
-   "metadata": {
-    "id": "bca751c7"
-   },
-   "source": [
-    "## API Endpoints"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e74fc609",
-   "metadata": {
-    "id": "e74fc609"
-   },
-   "outputs": [],
-   "source": [
-    "PIPELINE_SEARCH = API_URL + \"pipeline/search\"\n",
-    "AGENT_LIST = API_URL + \"agents?include=labels\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "915b0140",
-   "metadata": {
-    "id": "915b0140"
-   },
-   "source": [
-    "## Export Info Sheet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d6c34d00",
-   "metadata": {
-    "id": "d6c34d00"
-   },
-   "outputs": [],
-   "source": [
-    "info_data = {\"Name\": [\"timestamp\", \"API_URL\", \"ORG_SLUG\", \"TZ_IDENTIFIER\"], \"Value\": [timestamp, API_URL, ORG_SLUG, TZ_IDENTIFIER]}\n",
-    "info_df = pd.DataFrame(data=info_data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dd3cf0ea",
-   "metadata": {
-    "id": "dd3cf0ea"
-   },
-   "outputs": [],
-   "source": [
-    "print(info_df.to_string(index=False, header=False))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f1fad526",
-   "metadata": {
-    "id": "f1fad526"
-   },
-   "source": [
-    "## Pipeline Configuration Sheet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f0b7f212",
-   "metadata": {
-    "id": "f0b7f212"
-   },
-   "outputs": [],
-   "source": [
-    "def get_pipeline_page(headers, **kwargs):\n",
-    "    \"\"\"\n",
-    "        Returns a set of pipelines and whether there are more\n",
-    "        pipelines remaining\n",
-    "        Optional args: page_size, page_index\n",
-    "    \"\"\"\n",
-    "    pipeline_api = PIPELINE_SEARCH + \"?\"\n",
-    "    if \"index\" in kwargs.keys():\n",
-    "        page_index = kwargs[\"index\"]\n",
-    "        pipeline_api += \"from=\" + str(page_index) + \"&\"\n",
-    "    if \"size\" in kwargs.keys():\n",
-    "        page_size = kwargs[\"size\"]\n",
-    "        pipeline_api += \"size=\" + str(page_size) + \"&\"\n",
-    "\n",
-    "    pipeline_response = requests.get(pipeline_api, headers=headers)\n",
-    "    pipeline_response = json.loads(pipeline_response.text)\n",
-    "\n",
-    "    return pipeline_response[\"hits\"], pipeline_response[\"hasNext\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22c4af5c",
-   "metadata": {
-    "id": "22c4af5c"
-   },
-   "outputs": [],
-   "source": [
-    "def get_all_pipelines(headers, size=1):\n",
-    "    \"\"\"\n",
-    "        Returns list of all pipelines by iterating over full list\n",
-    "        by the size parameter.\n",
-    "    \"\"\"\n",
-    "    hasNext = True\n",
-    "    index = 0\n",
-    "    all_pipelines = []\n",
-    "    while hasNext == True:\n",
-    "        pipes, hasNext = get_pipeline_page(headers, size=size, index=index)\n",
-    "        all_pipelines += pipes\n",
-    "        index += 1\n",
-    "    return all_pipelines"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2f91685d",
-   "metadata": {
-    "id": "2f91685d"
-   },
-   "outputs": [],
-   "source": [
-    "pipeline_list = get_all_pipelines(headers)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d8f49795",
-   "metadata": {
-    "id": "d8f49795"
-   },
-   "outputs": [],
-   "source": [
-    "pipeline_top_fields = [\"id\",\n",
-    "                        \"name\",\n",
-    "                        \"description\",\n",
-    "                        \"status\",\n",
-    "                        \"createdAt\",\n",
-    "                        \"updatedAt\",\n",
-    "                        \"triggerCondition\",\n",
-    "                        \"maxParallelWorkflows\",\n",
-    "                        \"priority\",\n",
-    "                        \"retryBehavior\",\n",
-    "                        \"retryConfiguration\",\n",
-    "                        \"protocolSlug\",\n",
-    "                        \"protocolVersion\",\n",
-    "                        \"pipelineConfig\",\n",
-    "                        \"stepsConfig\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "28164873",
-   "metadata": {
-    "id": "28164873"
-   },
-   "outputs": [],
-   "source": [
-    "def pipeline_summary(pipeline_info, org):\n",
-    "\n",
-    "    pipeline_top_vals = [org] + [pipeline_info[x] for x in pipeline_top_fields]\n",
-    "\n",
-    "    return pipeline_top_vals"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d6318362",
-   "metadata": {
-    "id": "d6318362"
-   },
-   "outputs": [],
-   "source": [
-    "pipeline_summaries = [pipeline_summary(a, ORG_SLUG) for a in pipeline_list]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30368c21",
-   "metadata": {
-    "id": "30368c21"
-   },
-   "outputs": [],
-   "source": [
-    "pipeline_df = pd.DataFrame(pipeline_summaries, columns = [\"orgSlug\"] + pipeline_top_fields)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "beeb724f",
-   "metadata": {
-    "id": "beeb724f",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "pipeline_df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "845bfbe0",
-   "metadata": {
-    "id": "845bfbe0"
-   },
-   "source": [
-    "## Agent Configuration Sheet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bb8e0a4c",
-   "metadata": {
-    "id": "bb8e0a4c"
-   },
-   "outputs": [],
-   "source": [
-    "agent_response = requests.get(AGENT_LIST, headers=headers)\n",
-    "agent_list = json.loads(agent_response.text)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4530ffa0",
-   "metadata": {
-    "id": "4530ffa0"
-   },
-   "outputs": [],
-   "source": [
-    "agent_list"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1dfc37ac",
-   "metadata": {
-    "id": "1dfc37ac"
-   },
-   "outputs": [],
-   "source": [
-    "agent_top_fields = [\"orgSlug\",\n",
-    "                    \"name\",\n",
-    "                    \"description\",\n",
-    "                    \"id\",\n",
-    "                    \"isEnabled\",\n",
-    "                    \"status\",\n",
-    "                    \"version\",\n",
-    "                    \"labels\",\n",
-    "                    \"tags\",\n",
-    "                    \"metadata\",\n",
-    "                    \"host\",\n",
-    "                    \"createdAt\",\n",
-    "                    \"updatedAt\",\n",
-    "                    \"configStatusUpdatedAt\",\n",
-    "                    \"type\",\n",
-    "                    \"liveType\",\n",
-    "                    \"integrationType\",\n",
-    "                    \"integrationId\"]\n",
-    "agent_queue_fields = [\"queue_enabled\"]\n",
-    "agent_paths_fields = [\"paths\",\n",
-    "                      \"paths_start_date\",\n",
-    "                      \"paths_source_type\",\n",
-    "                      \"paths_interval\",\n",
-    "                      \"paths_labels\",\n",
-    "                      \"paths_tags\",\n",
-    "                      \"paths_metadata\",\n",
-    "                      \"paths_patterns\",\n",
-    "                      \"paths_filewatchmode\",\n",
-    "                      \"paths_fetch_os_created_user\",\n",
-    "                      \"paths_archive\"]\n",
-    "agent_fields = agent_top_fields + agent_queue_fields + agent_paths_fields"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "754f5566",
-   "metadata": {
-    "id": "754f5566"
-   },
-   "outputs": [],
-   "source": [
-    "def try_getting_from_path(path_info, field):\n",
-    "    try:\n",
-    "        return path_info[field]\n",
-    "    except:\n",
-    "        return None\n",
-    "\n",
-    "def agent_summary(agent_info):\n",
-    "\n",
-    "    agent_top_vals = [agent_info[x] for x in agent_top_fields]\n",
-    "\n",
-    "    if agent_info[\"queue\"]:\n",
-    "        agent_queue_vals = [agent_info[\"queue\"][\"enabled\"]]\n",
-    "    else:\n",
-    "        agent_queue_vals = [\"N/A\"]*len(agent_queue_fields)\n",
-    "\n",
-    "    # Additionally get File-Log Agent Configuration Information\n",
-    "    if (agent_info[\"type\"] == \"file-log\") and (agent_info[\"config\"] is not None):\n",
-    "        paths_info = agent_info[\"config\"][\"services_configuration\"][\"fileWatcher\"][\"paths\"]\n",
-    "\n",
-    "        agent_subvals = [[x[\"path\"] for x in paths_info],\n",
-    "                         [x[\"start_date\"] for x in paths_info],\n",
-    "                         [x[\"source_type\"] for x in paths_info],\n",
-    "                         [x[\"interval\"] for x in paths_info],\n",
-    "                         [try_getting_from_path(x, \"labels\") for x in paths_info],\n",
-    "                         [try_getting_from_path(x, \"metadata\") for x in paths_info],\n",
-    "                         [try_getting_from_path(x, \"tags\") for x in paths_info],\n",
-    "                         [x[\"patterns\"] for x in paths_info],\n",
-    "                         [x[\"file_watch_mode\"] for x in paths_info],\n",
-    "                         [try_getting_from_path(x, \"fetch_os_created_user\") for x in paths_info],\n",
-    "                         [try_getting_from_path(x, \"archive\") for x in paths_info]]\n",
-    "    else:\n",
-    "        agent_subvals = [\"N/A\"]*len(agent_paths_fields)\n",
-    "\n",
-    "    return agent_top_vals + agent_queue_vals + agent_subvals"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f8dbfd7d",
-   "metadata": {
-    "id": "f8dbfd7d"
-   },
-   "outputs": [],
-   "source": [
-    "agent_summaries = [agent_summary(a) for a in agent_list]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a1d31f50",
-   "metadata": {
-    "id": "a1d31f50"
-   },
-   "outputs": [],
-   "source": [
-    "agent_df = pd.DataFrame(agent_summaries, columns = agent_fields)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e2441f6d",
-   "metadata": {
-    "id": "e2441f6d",
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "agent_df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d4afdf04",
-   "metadata": {
-    "id": "d4afdf04"
-   },
-   "source": [
-    "## Save to Excel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb40222e",
-   "metadata": {
-    "id": "fb40222e"
-   },
-   "outputs": [],
-   "source": [
-    "with pd.ExcelWriter(savefile_name) as writer:\n",
-    "    info_df.to_excel(writer, sheet_name='Info', index=False, header=False)\n",
-    "    agent_df.to_excel(writer, sheet_name='Agent Cfg', index=False)\n",
-    "    pipeline_df.to_excel(writer, sheet_name='Pipeline Cfg', index=False)"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
* Add `config.destination_id` to the report, currently only reported if set in the FLA.
* Update the markdown for setting the TDP API URL.

Graphical diff:
https://drive.google.com/file/d/1LB2WEPn4ESQvTntK9y91OLQtXOZth938/view?usp=drive_link
Select "Open with" and then your browser to open the HTML file and render it.